### PR TITLE
サブプロジェクトとマクロの変更、ウィンドウサイズの調整

### DIFF
--- a/Game/Scene/Factory/SceneFactory.cpp
+++ b/Game/Scene/Factory/SceneFactory.cpp
@@ -6,7 +6,7 @@
 
 #include <cassert>
 
-#define JUDGE_SCENE_NAME(_scName) if (_sceneName == #_scName) pNewScene = new _scName();
+#define JUDGE_SCENE_NAME(class) if (_sceneName == #class) pNewScene = new class();
 
 IScene* SceneFactory::CreateScene(const std::string& _sceneName)
 {

--- a/Game/imgui.ini
+++ b/Game/imgui.ini
@@ -10,7 +10,7 @@ Collapsed=0
 
 [Window][Objects]
 Pos=956,4
-Size=141,246
+Size=144,277
 Collapsed=0
 
 [Window][デバッグ]
@@ -20,7 +20,7 @@ Collapsed=0
 
 [Window][SRVManager]
 Pos=60,60
-Size=129,86
+Size=233,91
 Collapsed=0
 
 [Table][0x3A809993,2]


### PR DESCRIPTION
`SceneFactory.cpp` では、`#define JUDGE_SCENE_NAME(_scName)` マクロが `#define JUDGE_SCENE_NAME(class)` に変更され、マクロの引数名が `_scName` から `class` に変更されました。